### PR TITLE
Use an alias target for the root add_library

### DIFF
--- a/gz-utils-config.cmake.in
+++ b/gz-utils-config.cmake.in
@@ -21,5 +21,4 @@ foreach(component ${components})
 endforeach()
 
 # Add a root gz-lib alias
-add_library(@LIB_NAME_COMP_PREFIX@ INTERFACE IMPORTED)
-target_link_libraries(@LIB_NAME_COMP_PREFIX@ INTERFACE @LIB_NAME_COMP_PREFIX@::@LIB_NAME_COMP_PREFIX@)
+add_library(@LIB_NAME_COMP_PREFIX@ ALIAS @LIB_NAME@@LIB_VER_MAJOR@::@LIB_NAME@@LIB_VER_MAJOR@)


### PR DESCRIPTION
Without this patch, doing `find_package(gz-utils)` (or any vendor package) multiple times in a single CMakeLists file fails with an error indicating that cmake cannot create the imported target because another target with the same name already exists.


Test:

```cmake
cmake_minimum_required(VERSION 3.10)
project(test_gz_vendor)

find_package(gz_utils_vendor REQUIRED)
find_package(gz-utils REQUIRED)
find_package(gz-utils REQUIRED)

```
Once approved, I'll apply the change to the template and regenerate all vendor packages.