### PR TITLE
Add in a dependency on spdlog_vendor.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(ament_cmake_vendor_package REQUIRED)
 find_package(ament_cmake_export_dependencies REQUIRED)
 
 find_package(gz_cmake_vendor REQUIRED)
+find_package(spdlog_vendor REQUIRED)
 
 # Set the VERSION_MATCH to "EXACT" by default, but relax the requirement
 # if we are users are building from source (determined by the

--- a/package.xml
+++ b/package.xml
@@ -24,8 +24,6 @@
   <buildtool_depend>ament_cmake_test</buildtool_depend>
   <buildtool_depend>ament_cmake_vendor_package</buildtool_depend>
 
-  <build_depend>spdlog</build_depend>
-  <exec_depend>spdlog</exec_depend>
   <build_depend>spdlog_vendor</build_depend>
   <exec_depend>spdlog_vendor</exec_depend>
   <depend>gz_cmake_vendor</depend>

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,8 @@
 
   <build_depend>spdlog</build_depend>
   <exec_depend>spdlog</exec_depend>
+  <build_depend>spdlog_vendor</build_depend>
+  <exec_depend>spdlog_vendor</exec_depend>
   <depend>gz_cmake_vendor</depend>
 
   <!-- Depend on the package we are vendoring to allow building it from source -->


### PR DESCRIPTION
That way when building on e.g. Windows, the paths to spdlog will be setup properly before trying to build this vendor package.